### PR TITLE
config: add eas to project

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -21,6 +21,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   assetBundlePatterns: ['**/*'],
   ios: {
     supportsTablet: true,
+    bundleIdentifier: 'com.timelin.mobile',
   },
   android: {
     adaptiveIcon: {
@@ -50,7 +51,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     appId: process.env.FIREBASE_APP_ID,
     measurementId: process.env.FIREBASE_MEASUREMENT_ID,
     appName: 'timelin-mobile',
+    eas: {
+      projectId: 'd0d6955c-36c9-4246-8d5f-fc8446f4eaef',
+    },
   },
 });
-
-console.log(process.env.FIREBASE_PROJECT_ID);

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,26 @@
+{
+  "cli": {
+    "version": ">= 3.12.0"
+  },
+
+  "build": {
+    "development-simulator": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint": "^8.19.0",
     "expo": "^47.0.0",
     "expo-constants": "14.0.2",
+    "expo-dev-client": "~2.0.1",
     "expo-image-picker": "~14.0.2",
     "expo-splash-screen": "~0.17.5",
     "expo-status-bar": "~1.4.2",

--- a/src/ui/atoms/typography/index.tsx
+++ b/src/ui/atoms/typography/index.tsx
@@ -9,7 +9,8 @@ const StyledText = styled.Text<{
   colour?: string;
 }>`
   font-size: ${(props) => props.theme.typography.sizes[props.size]}px;
-  font-weight: ${(props) => (props.weight ? props.weight : 'regular')};
+  font-weight: ${(props) =>
+    props.weight ? props.theme.typography.weight[props.weight] : props.theme.typography.weight['regular']};
   color: ${({ theme: { colours }, colour }) =>
     colour ? colour : colours.neutrals.dark};
 `;

--- a/src/ui/theme/types.ts
+++ b/src/ui/theme/types.ts
@@ -34,6 +34,19 @@ export interface DefaultTheme {
       large: number;
       heading: number;
     };
+    weight: {
+      regular: string;
+      bold: string;
+      100: number;
+      200: number;
+      300: number;
+      400: number;
+      500: number;
+      600: number;
+      medium: number;
+      800: number;
+      900: number;
+    };
   };
   shadow: { [K in Shadow]: string };
 }

--- a/src/ui/tokens/typography.ts
+++ b/src/ui/tokens/typography.ts
@@ -7,6 +7,21 @@ const sizes: DefaultTheme['typography']['sizes'] = {
   heading: 24,
 };
 
+const weight: DefaultTheme['typography']['weight'] = {
+  '100': 100,
+  '200': 200,
+  '300': 300,
+  '400': 400,
+  '500': 500,
+  '600': 600,
+  medium: 500,
+  '800': 800,
+  '900': 900,
+  bold: 'bold',
+  regular: 'normal',
+};
+
 export const typography = {
   sizes,
+  weight
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5346,6 +5346,39 @@ expo-constants@14.0.2, expo-constants@~14.0.0, expo-constants@~14.0.2:
     "@expo/config" "~7.0.2"
     uuid "^3.3.2"
 
+expo-dev-client@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/expo-dev-client/-/expo-dev-client-2.0.1.tgz#f5878807c96a60d90fc219b6535654cb6ddb9214"
+  integrity sha512-+OXXZKKo/CplqklpaZasHAX7qaRrzC83biqXTFa1z5NiFW41uqtAqTFx6gmPi4kx3YgwtD+ep6R3SRrKjdCukg==
+  dependencies:
+    expo-dev-launcher "2.0.2"
+    expo-dev-menu "2.0.2"
+    expo-dev-menu-interface "1.0.0"
+    expo-manifests "~0.4.0"
+    expo-updates-interface "~0.8.0"
+
+expo-dev-launcher@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expo-dev-launcher/-/expo-dev-launcher-2.0.2.tgz#bbcde0dd35e81ed6a415dc5b246da68e9b365255"
+  integrity sha512-MQT7VSOHJQrEs3YAv5BQLYs3Uk7P1dNqBw6kKrj3jKBq0z92k2LLg1aCk7nP8OGJVDvrb2jTXBka8VXVqF0ECg==
+  dependencies:
+    expo-dev-menu "2.0.2"
+    resolve-from "^5.0.0"
+    semver "^7.3.5"
+
+expo-dev-menu-interface@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/expo-dev-menu-interface/-/expo-dev-menu-interface-1.0.0.tgz#00204cb7e1c43cc8a4eee9cb74f6e5760b512d75"
+  integrity sha512-4lsVofTwV9oBM+zo7XhtmvbfiXD4I7I3Rqns6U0i6IOnH7OGBDpKvGZ5YikWPFGn6NOu8loqqd8S7inFIaxC0A==
+
+expo-dev-menu@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expo-dev-menu/-/expo-dev-menu-2.0.2.tgz#9a2d7a00097d4eafe54cf8e9a5c727174e101e4c"
+  integrity sha512-SxR5riXgm+VVKsDKC/bOLuOJ0CKutW07G+OqJ9eYfxwGfxa8omLJHwagbCsd8FwUPGkzvzgfRJRGLo5J6REMow==
+  dependencies:
+    expo-dev-menu-interface "1.0.0"
+    semver "^7.3.5"
+
 expo-eas-client@~0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/expo-eas-client/-/expo-eas-client-0.4.1.tgz#4ccdafb5faeac97394fb3fa4c777ec22b2017f1d"


### PR DESCRIPTION
This is a new configuration to have native apps in the emulator or simulator instead of using expo go